### PR TITLE
Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Kafka Example
+
+Setup
+
+Run
+
+```bash
+docker-compose up -d
+```
+
+Then run with
+
+```bash
+cargo run
+```
+
+You can see a list of useful kafka scripts with
+
+```
+docker-compose exec -w /opt/bitnami/kafka/bin kafka ls
+```
+
+For example
+
+```
+docker-compose exec -w /opt/bitnami/kafka/bin kafka ./kafka-topics.sh --list --zookeeper zookeeper:2181
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "2"
+
+services:
+  zookeeper:
+    network_mode: host
+    image: docker.io/bitnami/zookeeper:3
+    ports:
+      - "2181:2181"
+    volumes:
+      - "zookeeper_data:/bitnami"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    network_mode: host
+    image: docker.io/bitnami/kafka:2
+    ports:
+      - "9092:9092"
+    volumes:
+      - "kafka_data:/bitnami"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=127.0.0.1:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    depends_on:
+      - zookeeper


### PR DESCRIPTION
Some minor tweaks. I added a quick and dirty docker-compose file which is how I'm running Kafka+Zookeeper on my local machine, and changed it to not use the consumer group plumbing as we don't need it for IOx.

I can't replicate the consumer lag you were seeing, I wonder if this might have been caused by using the consumer group functionality and the consumer therefore waiting for partitions to be assigned to it.